### PR TITLE
removed unnecessary condition in toArray of Response

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -53,10 +53,8 @@ class Response
      */
     protected function toArray()
     {
-        if (isset($this->error)) {
+        if (property_exists($this, 'error')) {
             return ['error' => $this->error, 'message' => $this->message];
-        } elseif ($this->user->getName() === '') {
-            return $this->user->toArray();
         } else {
             return $this->signJsConnect();
         }

--- a/test/Tests/ResponseTest.php
+++ b/test/Tests/ResponseTest.php
@@ -56,6 +56,32 @@ class ResponseTests extends \PHPUnit_Framework_TestCase {
 		]);
 
 		$errorResponse = new UnsignedResponse($request, $user);
+		$this->assertEquals($expectedResult, (string)$errorResponse);
+	}
+
+	public function testToArrayEmptyUser() {
+		$request = $this->getMockBuilder('\Zumba\VanillaJsConnect\Request')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$user = $this->getMockBuilder('\Zumba\VanillaJsConnect\User')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$user
+			->method('getName')
+			->will($this->returnValue(''));
+
+		$user
+			->method('getPhotoUrl')
+			->will($this->returnValue(''));
+
+		$expectedResult = json_encode([
+				'name' => '',
+				'photourl' => ''
+		]);
+
+		$errorResponse = new UnsignedResponse($request, $user);
 
 		$this->assertEquals($expectedResult, (string)$errorResponse);
 	}


### PR DESCRIPTION
isset error isn't a good check if the object has an error property.
user->getName should never be called because user will not always be defined. 
