### PR TITLE
prevented extra properties from showing in errors

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -93,7 +93,7 @@ class Response
      */
     public function __toString()
     {
-        if ($this instanceof ErrorResponse) {
+        if (get_class($this) !== "Zumba\VanillaJsConnect\Response") {
             return json_encode($this->toArray());
         }
         $resultArray = array_merge($this->toArray(), $this->properties);

--- a/src/Response.php
+++ b/src/Response.php
@@ -77,6 +77,15 @@ class Response
     }
 
     /**
+     * Only the 'valid' response should send added properties
+     *
+     * @return string
+     */
+    protected function encodeResponse() {
+      return json_encode(array_merge($this->toArray(), $this->properties));
+    }
+
+    /**
      * Saves an array that will be merged with the User object array
      *
      * @param  array $props
@@ -86,6 +95,7 @@ class Response
     {
         $this->properties = array_merge($this->properties, $props);
     }
+
     /**
      * Allows response to be type cast into a string when handling
      *
@@ -93,11 +103,8 @@ class Response
      */
     public function __toString()
     {
-        if (get_class($this) !== "Zumba\VanillaJsConnect\Response") {
-            return json_encode($this->toArray());
-        }
-        $resultArray = array_merge($this->toArray(), $this->properties);
-        $resultJSON = json_encode($resultArray);
+        $resultJSON = $this->encodeResponse();
+
         $callback = $this->request->getCallback();
         if (!empty($callback)) {
             return "$callback($resultJSON)";

--- a/src/Response.php
+++ b/src/Response.php
@@ -81,8 +81,9 @@ class Response
      *
      * @return string
      */
-    protected function encodeResponse() {
-      return json_encode(array_merge($this->toArray(), $this->properties));
+    protected function encodeResponse()
+    {
+        return json_encode(array_merge($this->toArray(), $this->properties));
     }
 
     /**

--- a/src/Response/ExpiredTimestamp.php
+++ b/src/Response/ExpiredTimestamp.php
@@ -17,4 +17,14 @@ class ExpiredTimestamp extends \Zumba\VanillaJsConnect\Response
      * @var string
      */
     protected $message = 'The timestamp is invalid.';
+
+    /**
+     * 'Error' responses do not return added properties
+     *
+     * @return string
+     */
+    protected function encodeResponse()
+    {
+        return json_encode($this->toArray());
+    }
 }

--- a/src/Response/InvalidClientID.php
+++ b/src/Response/InvalidClientID.php
@@ -26,6 +26,16 @@ class InvalidClientID extends \Zumba\VanillaJsConnect\Response
     protected $message = "Unknown client %s.";
 
     /**
+     * 'Error' responses do not return added properties
+     *
+     * @return string
+     */
+    protected function encodeResponse()
+    {
+        return json_encode($this->toArray());
+    }
+
+    /**
      * Sets the client id for toArray
      *
      * @param  string $clientID

--- a/src/Response/InvalidSignature.php
+++ b/src/Response/InvalidSignature.php
@@ -17,4 +17,14 @@ class InvalidSignature extends \Zumba\VanillaJsConnect\Response
      * @var string
      */
     protected $message = 'Signature invalid.';
+
+    /**
+     * 'Error' responses do not return added properties
+     *
+     * @return string
+     */
+    protected function encodeResponse()
+    {
+        return json_encode($this->toArray());
+    }
 }

--- a/src/Response/InvalidTimestamp.php
+++ b/src/Response/InvalidTimestamp.php
@@ -16,4 +16,14 @@ class InvalidTimestamp extends \Zumba\VanillaJsConnect\Response
      * @var string
      */
     protected $message = 'The timestamp parameter is missing or invalid.';
+
+    /**
+     * 'Error' responses do not return added properties
+     *
+     * @return string
+     */
+    protected function encodeResponse()
+    {
+        return json_encode($this->toArray());
+    }
 }

--- a/src/Response/MissingClientID.php
+++ b/src/Response/MissingClientID.php
@@ -17,4 +17,14 @@ class MissingClientID extends \Zumba\VanillaJsConnect\Response
      * @var string
      */
     protected $message = 'The client_id parameter is missing.';
+
+    /**
+     * 'Error' responses do not return added properties
+     *
+     * @return string
+     */
+    protected function encodeResponse()
+    {
+        return json_encode($this->toArray());
+    }
 }

--- a/src/Response/MissingSignature.php
+++ b/src/Response/MissingSignature.php
@@ -17,4 +17,14 @@ class MissingSignature extends \Zumba\VanillaJsConnect\Response
      * @var string
      */
     protected $message = 'Missing  signature parameter.';
+
+    /**
+     * 'Error' responses do not return added properties
+     *
+     * @return string
+     */
+    protected function encodeResponse()
+    {
+        return json_encode($this->toArray());
+    }
 }

--- a/src/Response/UnsignedRequest.php
+++ b/src/Response/UnsignedRequest.php
@@ -75,4 +75,14 @@ class UnsignedRequest extends \Zumba\VanillaJsConnect\Response
         }
 
     }
+
+    /**
+     * 'Error' responses do not return added properties
+     *
+     * @return string
+     */
+    protected function encodeResponse()
+    {
+        return json_encode($this->toArray());
+    }
 }

--- a/test/Tests/ResponseTest.php
+++ b/test/Tests/ResponseTest.php
@@ -159,14 +159,14 @@ class ResponseTests extends \PHPUnit_Framework_TestCase {
 			->will($this->returnValue('Bar007'));
 
 		$response = new Response($request, $user, $config);
-		$response->addProperties(['test' => 'poop', 'cake' => 'lie']);
+		$response->addProperties(['test' => 'more', 'cake' => 'lie']);
 
 		$expectedResult = json_encode([
 				'name' => 'Foo',
 				'photourl' => 'imgur',
 				'client_id' => 'Bar007',
 				'signature' => 'd8174f110c2e4cb0811099b4a9ce819e',
-				'test' => 'poop',
+				'test' => 'more',
 				'cake' => 'lie'
 		]);
 

--- a/test/Tests/ResponseTest.php
+++ b/test/Tests/ResponseTest.php
@@ -173,6 +173,44 @@ class ResponseTests extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals($expectedResult, (string)$response);
 	}
 
+	public function testAddPropertiesWithError() {
+		$request = $this->getMockBuilder('\Zumba\VanillaJsConnect\Request')
+			->disableOriginalConstructor()
+			->getMock();
+		$user = $this->getMockBuilder('\Zumba\VanillaJsConnect\User')
+			->disableOriginalConstructor()
+			->getMock();
+		$config = $this->getMockBuilder('\Zumba\VanillaJsConnect\Config')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$user
+			->method('getName')
+			->will($this->returnValue(''));
+
+		$user
+			->method('getPhotoUrl')
+			->will($this->returnValue(''));
+
+		$config
+			->method('getSecret')
+			->will($this->returnValue('cake'));
+
+		$config
+			->method('getClientID')
+			->will($this->returnValue('Bar007'));
+
+		$response = new Response\UnsignedRequest($request, $user, $config);
+		$response->addProperties(['test' => 'more', 'cake' => 'lie']);
+
+		$expectedResult = json_encode([
+				'name' => '',
+				'photourl' => '',
+		]);
+
+		$this->assertEquals($expectedResult, (string)$response);
+	}
+
 	public function testCallback() {
 		$request = $this->getMockBuilder('\Zumba\VanillaJsConnect\Request')
 			->disableOriginalConstructor()


### PR DESCRIPTION
Removes check for if ErrorClass when adding additionalProperties attached to the Response Object.

Refactored toString to call encodeResponse and then handle the callback logic. 
encodeResponse includes additional properties only on the valid Response.
