### PR TITLE
Include all user fields in signature

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -67,12 +67,13 @@ class Response
    */
     protected function signJsConnect()
     {
-        $userArray = $this->user->toArray();
-        $queryString = http_build_query($userArray, null, '&');
+        $queryArray = array_merge($this->user->toArray(), $this->properties);
+        ksort($queryArray);
+        $queryString = http_build_query($queryArray, null, '&');
         $signature = md5($queryString.$this->config->getSecret());
-        $userArray['client_id'] = $this->config->getClientID();
-        $userArray['signature'] = $signature;
-        return $userArray;
+        $queryArray['client_id'] = $this->config->getClientID();
+        $queryArray['signature'] = $signature;
+        return $queryArray;
 
     }
 
@@ -83,7 +84,7 @@ class Response
      */
     protected function encodeResponse()
     {
-        return json_encode(array_merge($this->toArray(), $this->properties));
+        return json_encode($this->toArray());
     }
 
     /**

--- a/test/Tests/ResponseTest.php
+++ b/test/Tests/ResponseTest.php
@@ -161,13 +161,21 @@ class ResponseTests extends \PHPUnit_Framework_TestCase {
 		$response = new Response($request, $user, $config);
 		$response->addProperties(['test' => 'more', 'cake' => 'lie']);
 
+		$queryArray = [
+			'cake' => 'lie',
+			'name' => 'Foo',
+			'photourl' => 'imgur',
+			'test' => 'more'
+		];
+
+		$signature = md5(http_build_query($queryArray, NULL, '&').'cake');
 		$expectedResult = json_encode([
+				'cake' => 'lie',
 				'name' => 'Foo',
 				'photourl' => 'imgur',
-				'client_id' => 'Bar007',
-				'signature' => 'd8174f110c2e4cb0811099b4a9ce819e',
 				'test' => 'more',
-				'cake' => 'lie'
+				'client_id' => 'Bar007',
+				'signature' => $signature,
 		]);
 
 		$this->assertEquals($expectedResult, (string)$response);


### PR DESCRIPTION
Vanilla documentation is unclear about this, but a developer specified that roles and any custom fields should be included in the signature hash.
