### PR TITLE
Rather than causing an error, check for config when it is needed and …

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -3,6 +3,7 @@
 namespace Zumba\VanillaJsConnect;
 
 use Firebase\JWT\JWT;
+use LogicException;
 use Zumba\VanillaJsConnect\Contracts\ErrorResponseInterface;
 use Zumba\VanillaJsConnect\Contracts\VanillaUser;
 
@@ -116,9 +117,13 @@ class Response
      *
      * @param array $payload
      * @return string
+     * @throws \LogicException
      */
     protected function jwtEncode(array $payload)
     {
+        if (empty($this->config)) {
+            throw new LogicException('Cannot encode jwt without configuration set');
+        }
         // validate and decode the token from request
         $decodedRequest = $this->decodeToken($this->request->getToken());
 
@@ -198,10 +203,14 @@ class Response
      *
      * @param string $requestToken
      * @return array
+     * @throws \LogicException
      */
     protected function decodeToken(string $requestToken) : array
     {
         if (empty(static::$runtimeDecodedToken)) {
+            if (empty($this->config)) {
+                throw new LogicException('Cannot decode token without configuration set');
+            }
             $payload = JWT::decode(
                 $requestToken,
                 $this->config->getSecret(),

--- a/test/Tests/ResponseTest.php
+++ b/test/Tests/ResponseTest.php
@@ -2,15 +2,15 @@
 
 namespace Tests;
 
-use Firebase\JWT\JWK;
 use Firebase\JWT\JWT;
-use \Zumba\VanillaJsConnect\SSO;
-use \Zumba\VanillaJsConnect\Config;
-use \Zumba\VanillaJsConnect\Request;
-use \Zumba\VanillaJsConnect\Response as Response;
-use \Zumba\VanillaJsConnect\User;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+use Zumba\VanillaJsConnect\Config;
+use Zumba\VanillaJsConnect\Request;
+use Zumba\VanillaJsConnect\Response as Response;
+use Zumba\VanillaJsConnect\User;
 
-class ResponseTest extends \PHPUnit\Framework\TestCase {
+class ResponseTest extends TestCase {
 
     /**
      * Test case toArray is called on an error response
@@ -190,6 +190,24 @@ class ResponseTest extends \PHPUnit\Framework\TestCase {
         ]);
 
         $this->assertEquals($expectedResult, (string)$response);
+    }
+
+    public function testEncodeResponseNoConfig() {
+        $request = new Request('jwt');
+        $response = new Response($request);
+
+        // Should not try to encode response if there is no config
+        $this->expectException(LogicException::class);
+        $response->encodeResponse();
+    }
+
+    public function testGetRedirectUrlNoConfig() {
+        $request = new Request('jwt');
+        $response = new Response($request);
+
+        // Should not try to get redirect url if there is no config
+        $this->expectException(LogicException::class);
+        $response->getRedirectUrl();
     }
 
 }


### PR DESCRIPTION
…throw an exception if missing

This addresses a problem: if you try to do something like `$response->getRedirectUrl()` when there is no config set in the response, before it would give an error like:

> Cannot call `getSecret()` on `null` (paraphrased)

This checks for the config in any methods that need it to work, and throws a logic exception instead of just letting it cause a PHP error that can't be caught.